### PR TITLE
Fix PHP8 string offset syntax

### DIFF
--- a/eyeos/system/kernel/libs/log4php/helpers/LoggerPatternParser.php
+++ b/eyeos/system/kernel/libs/log4php/helpers/LoggerPatternParser.php
@@ -112,7 +112,7 @@ class LoggerPatternParser {
 	 * @return string
 	 */
 	public function extractOption() {
-		if(($this->i < $this->patternLength) and ($this->pattern{$this->i} == '{')) {
+               if(($this->i < $this->patternLength) and ($this->pattern[$this->i] == '{')) {
 			$end = strpos($this->pattern, '}' , $this->i);
 			if($end !== false) {
 				$r = substr($this->pattern, ($this->i + 1), ($end - $this->i - 1));
@@ -151,18 +151,18 @@ class LoggerPatternParser {
 		$this->i = 0;
 		$this->currentLiteral = '';
 		while($this->i < $this->patternLength) {
-			$c = $this->pattern{$this->i++};
+               $c = $this->pattern[$this->i++];
 
 			switch($this->state) {
 				case self::LITERAL_STATE:
 					// In literal state, the last char is always a literal.
 					if($this->i == $this->patternLength) {
-						$this->currentLiteral .= $c;
-						continue;
+                                               $this->currentLiteral .= $c;
+                                               continue 2;
 					}
 					if($c == self::ESCAPE_CHAR) {
 						// peek at the next char.
-						switch($this->pattern{$this->i}) {
+                                               switch($this->pattern[$this->i]) {
 							case self::ESCAPE_CHAR:
 								$this->currentLiteral .= $c;
 								$this->i++; // move pointer
@@ -304,7 +304,7 @@ class LoggerPatternParser {
 				break;
 			case 'u':
 				if($this->i < $this->patternLength) {
-					$cNext = $this->pattern{$this->i};
+                                       $cNext = $this->pattern[$this->i];
 					if(ord($cNext) >= ord('0') and ord($cNext) <= ord('9')) {
 						$pc = new LoggerUserFieldPatternConverter($this->formattingInfo, (string)(ord($cNext) - ord('0')));
 						$this->currentLiteral = '';


### PR DESCRIPTION
## Summary
- update string offset access to array syntax in LoggerPatternParser
- use `continue 2` to correctly continue outer loop in literal state

## Testing
- `php -l system/kernel/libs/log4php/helpers/LoggerPatternParser.php`
- `phpunit --bootstrap ./tests/init.php ./tests` *(fails: Undefined constant "MB_OVERLOAD_STRING")*

------
https://chatgpt.com/codex/tasks/task_e_6840bea0040483308592e432bdfad15d